### PR TITLE
Allow custom pass and dbname

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export MYSQL_CUSTOM_ENV="USER=alpha;HOST=beta"
 
 # you can specify custom password and database name
 # variables
-export MYSQL_CUSTOM_PASSWORD="some-password"
+export MYSQL_PASSWORD="some-password"
 export MYSQL_DATABASE_NAME="some-database-name"
 
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ export MYSQL_IMAGE_VERSION="5.5"
 # in semi-colon separated forma
 export MYSQL_CUSTOM_ENV="USER=alpha;HOST=beta"
 
+# you can specify custom password and database name
+# variables
+export MYSQL_CUSTOM_PASSWORD="some-password"
+export MYSQL_DATABASE_NAME="some-database-name"
+
+
 # create a mysql service
 dokku mysql:create lolipop
 

--- a/commands
+++ b/commands
@@ -30,9 +30,16 @@ case "$1" in
     mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
     echo -e "[mysqld]\nperformance_schema = 0" > "$SERVICE_ROOT/config/disable_performance_schema.cnf"
     rootpassword=$(openssl rand -hex 8)
-    password=$(openssl rand -hex 8)
     echo "$rootpassword" > "$SERVICE_ROOT/ROOTPASSWORD"
-    echo "$password" > "$SERVICE_ROOT/PASSWORD"
+
+    if [[ -n $MYSQL_PASSWORD ]]; then
+      password="$MYSQL_PASSWORD"
+      echo "$password" > "$SERVICE_ROOT/PASSWORD"
+    else
+      password=$(openssl rand -hex 8)
+      echo "$password" > "$SERVICE_ROOT/PASSWORD"
+    fi
+
     chmod 640 "$SERVICE_ROOT/ROOTPASSWORD" "$SERVICE_ROOT/PASSWORD"
     touch "$LINKS_FILE"
 
@@ -42,8 +49,17 @@ case "$1" in
     else
       echo "" > "$SERVICE_ROOT/ENV"
     fi
+
+    if [[ -n $MYSQL_DATABASE_NAME ]]; then
+      DATABASE_NAME="$MYSQL_DATABASE_NAME"
+      echo "$DATABASE_NAME" > "$SERVICE_ROOT/DATABASE_NAME"
+    else
+      DATABASE_NAME=$(get_service_name "$SERVICE")
+    fi
+
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -v "$SERVICE_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ROOT_PASSWORD=$rootpassword" -e MYSQL_USER=mysql -e "MYSQL_PASSWORD=$password" -e "MYSQL_DATABASE=$SERVICE" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mysql "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -v "$SERVICE_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ROOT_PASSWORD=$rootpassword" -e MYSQL_USER=mysql -e "MYSQL_PASSWORD=$password" -e "MYSQL_DATABASE=$DATABASE_NAME" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mysql "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"
@@ -168,9 +184,16 @@ case "$1" in
     SERVICE="$2"; SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
     SERVICE_NAME="$(get_service_name "$SERVICE")"
     PASSWORD=$(cat "$SERVICE_ROOT/PASSWORD")
+
+    if [[ -e "$SERVICE_ROOT/DATABASE_NAME" ]]; then
+       DATABASE_NAME=$(cat "$SERVICE_ROOT/DATABASE_NAME")
+    else
+       DATABASE_NAME="$SERVICE"
+    fi
+
     has_tty && SERVICE_TTY_OPTS="-t"
 
-    docker exec -i $SERVICE_TTY_OPTS "$SERVICE_NAME" mysql --user=mysql --password="$PASSWORD" --database="$SERVICE"
+    docker exec -i $SERVICE_TTY_OPTS "$SERVICE_NAME" mysql --user=mysql --password="$PASSWORD" --database="$DATABASE_NAME"
     ;;
 
   $PLUGIN_COMMAND_PREFIX:info)

--- a/commands
+++ b/commands
@@ -54,7 +54,7 @@ case "$1" in
       DATABASE_NAME="$MYSQL_DATABASE_NAME"
       echo "$DATABASE_NAME" > "$SERVICE_ROOT/DATABASE_NAME"
     else
-      DATABASE_NAME=$(get_service_name "$SERVICE")
+      DATABASE_NAME="$SERVICE"
     fi
 
     SERVICE_NAME=$(get_service_name "$SERVICE")

--- a/commands
+++ b/commands
@@ -29,16 +29,16 @@ case "$1" in
     mkdir -p "$SERVICE_ROOT/data" || dokku_log_fail "Unable to create service data directory"
     mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
     echo -e "[mysqld]\nperformance_schema = 0" > "$SERVICE_ROOT/config/disable_performance_schema.cnf"
+    rootpassword=$(openssl rand -hex 8)
+    echo "$rootpassword" > "$SERVICE_ROOT/ROOTPASSWORD"
 
     if [[ -n $MYSQL_PASSWORD ]]; then
       password="$MYSQL_PASSWORD"
-      echo "$password" > "$SERVICE_ROOT/PASSWORD"
-      echo "$password" > "$SERVICE_ROOT/ROOTPASSWORD"
     else
       password=$(openssl rand -hex 8)
-      echo "$password" > "$SERVICE_ROOT/PASSWORD"
-      echo "$password" > "$SERVICE_ROOT/ROOTPASSWORD"
     fi
+
+    echo "$password" > "$SERVICE_ROOT/PASSWORD"
 
     chmod 640 "$SERVICE_ROOT/ROOTPASSWORD" "$SERVICE_ROOT/PASSWORD"
     touch "$LINKS_FILE"
@@ -59,7 +59,7 @@ case "$1" in
 
     SERVICE_NAME=$(get_service_name "$SERVICE")
 
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -v "$SERVICE_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mysql "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -v "$SERVICE_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ROOT_PASSWORD=$rootpassword" -e MYSQL_USER=mysql -e "MYSQL_PASSWORD=$password" -e "MYSQL_DATABASE=$DATABASE_NAME" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mysql "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"

--- a/commands
+++ b/commands
@@ -29,15 +29,15 @@ case "$1" in
     mkdir -p "$SERVICE_ROOT/data" || dokku_log_fail "Unable to create service data directory"
     mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
     echo -e "[mysqld]\nperformance_schema = 0" > "$SERVICE_ROOT/config/disable_performance_schema.cnf"
-    rootpassword=$(openssl rand -hex 8)
-    echo "$rootpassword" > "$SERVICE_ROOT/ROOTPASSWORD"
 
     if [[ -n $MYSQL_PASSWORD ]]; then
       password="$MYSQL_PASSWORD"
       echo "$password" > "$SERVICE_ROOT/PASSWORD"
+      echo "$password" > "$SERVICE_ROOT/ROOTPASSWORD"
     else
       password=$(openssl rand -hex 8)
       echo "$password" > "$SERVICE_ROOT/PASSWORD"
+      echo "$password" > "$SERVICE_ROOT/ROOTPASSWORD"
     fi
 
     chmod 640 "$SERVICE_ROOT/ROOTPASSWORD" "$SERVICE_ROOT/PASSWORD"
@@ -59,7 +59,7 @@ case "$1" in
 
     SERVICE_NAME=$(get_service_name "$SERVICE")
 
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -v "$SERVICE_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ROOT_PASSWORD=$rootpassword" -e MYSQL_USER=mysql -e "MYSQL_PASSWORD=$password" -e "MYSQL_DATABASE=$DATABASE_NAME" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mysql "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/mysql" -v "$SERVICE_ROOT/config:/etc/mysql/conf.d" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=mysql "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"

--- a/functions
+++ b/functions
@@ -279,7 +279,7 @@ service_url() {
   fi
   
   local SERVICE_ALIAS="$(service_alias "$SERVICE")"
-  echo "$PLUGIN_SCHEME://root:$PASSWORD@$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
+  echo "$PLUGIN_SCHEME://mysql:$PASSWORD@$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
 }
 
 is_container_status () {

--- a/functions
+++ b/functions
@@ -271,8 +271,15 @@ service_url() {
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
 
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
+
+  if [[ -e "$SERVICE_ROOT/DATABASE_NAME" ]];then
+    local DATABASE_NAME=$(cat "$SERVICE_ROOT/DATABASE_NAME")
+  else
+    local DATABASE_NAME="$SERVICE"
+  fi
+  
   local SERVICE_ALIAS="$(service_alias "$SERVICE")"
-  echo "$PLUGIN_SCHEME://mysql:$PASSWORD@$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$SERVICE"
+  echo "$PLUGIN_SCHEME://mysql:$PASSWORD@$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
 }
 
 is_container_status () {

--- a/functions
+++ b/functions
@@ -279,7 +279,7 @@ service_url() {
   fi
   
   local SERVICE_ALIAS="$(service_alias "$SERVICE")"
-  echo "$PLUGIN_SCHEME://mysql:$PASSWORD@$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
+  echo "$PLUGIN_SCHEME://root:$PASSWORD@$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
 }
 
 is_container_status () {

--- a/functions
+++ b/functions
@@ -272,7 +272,7 @@ service_url() {
 
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
-  if [[ -e "$SERVICE_ROOT/DATABASE_NAME" ]];then
+  if [[ -e "$SERVICE_ROOT/DATABASE_NAME" ]]; then
     local DATABASE_NAME=$(cat "$SERVICE_ROOT/DATABASE_NAME")
   else
     local DATABASE_NAME="$SERVICE"


### PR DESCRIPTION
This will allow custom MYSQL_PASSWORD and MYSQL_DATABASE_NAME environments.

This is very similar to what we did to POSTGRES plugin.

MYSQL also have root password which we don't expose we only expose mysql user.

@mkostick @justin-yesware 
